### PR TITLE
chapter 6 should reference :person/born

### DIFF
--- a/resources/chapters/chapter-6.md
+++ b/resources/chapters/chapter-6.md
@@ -18,8 +18,8 @@ with this function, we can now calculate the age of a person **inside the query 
      :in $ ?person ?today
      :where
      [?p :person/name ?name]
-     [?p :person/birth ?birth]
-     [(tutorial.fns/age ?birth ?today) ?age]]
+     [?p :person/born ?born]
+     [(tutorial.fns/age ?born ?today) ?age]]
 
 A transformation function clause has the shape `[(<fn> <arg1> <arg2> ...) <result-binding>]` where `<result-binding>` can be the same binding forms as we saw in [chapter 3](/chapter/3):
 


### PR DESCRIPTION
The following code for exercise 1 is wrong and I had to cheat (it should use `:person/born`)

``` clojure
[:find ?name
 :in $ ?age ?today
 :where
 [?p :person/name ?name] 
 [?p :person/birth ?birth]
 [(tutorial.fns/age ?birth ?today) ?age]]
```

However the example code in chapter 6 references `:person/birth`

``` clojure
[:find ?age
 :in $ ?person ?today
 :where
 [?p :person/name ?name]
 [?p :person/birth ?birth]
 [(tutorial.fns/age ?birth ?today) ?age]]
```
