### PR TITLE
Prevent the friend rule from allowing an actor to be their own friend

### DIFF
--- a/resources/chapters/chapter-8.edn
+++ b/resources/chapters/chapter-8.edn
@@ -24,14 +24,15 @@
               ...]]
      :correct-value [[(friends ?p1 ?p2)
                       [?m :movie/cast ?p1]
-                      [?m :movie/cast ?p2]]
+                      [?m :movie/cast ?p2]
+                      [(not= ?p1 ?p2)]]
                      [(friends ?p1 ?p2)
                       [?m :movie/cast ?p1]
                       [?m :movie/director ?p2]]
                      [(friends ?p1 ?p2)
                       (friends ?p2 ?p1)]]}
     {:type :value
-     :value "James Cameron"}]}
+     :value "Sigourney Weaver"}]}
 
   {:question "Write a rule `[sequels ?m1 ?m2]` where `?m1` and `?m2` are movie entities. You'll need to use the attribute `:movie/sequel`. To implement this rule correctly you can think of the problem like this: A movie `?m2` is a sequel of `?m1` if either 
 * `?m2` is the \"direct\" sequel of `m1` **or** 


### PR DESCRIPTION
As it stands now the `friends` rule is returning the actor themselves as a friend, since I believe they can satisfy both p1 and p2. I added a clause that p1 != p2, I think that's all that's necessary to fix it. I also changed the default person to Sigourney Weaver so the mistake would be checked for when running the query.

Seems like this bug could also exist if there were some Woody Allen movies in your database (actor and director), but doesn't seem to exist so I'm not gonna worry about that one :smile: 

 Awesome use of edn for this, super easy to understand.

![screen shot 2014-01-05 at 6 22 45 pm](https://f.cloud.github.com/assets/239754/1847675/50748da6-7660-11e3-83d0-ed4d4e264cf3.png)
