### PR TITLE
Parameter name must match in :in and :where clauses.

### DIFF
--- a/resources/chapters/chapter-6.md
+++ b/resources/chapters/chapter-6.md
@@ -15,7 +15,7 @@ person:
 with this function, we can now calculate the age of a person **inside the query itself**:
 
     [:find ?age
-     :in $ ?person ?today
+     :in $ ?name ?today
      :where
      [?p :person/name ?name]
      [?p :person/born ?born]


### PR DESCRIPTION
The example for Chapter 6 showed a query that was passed in a parameter ?person, but in the where clause it was referenced as [?p :person/name ?name]. I switched the parameter to ?name.
